### PR TITLE
Add noai subdomain to duckduckgo.yml

### DIFF
--- a/serpinfo/duckduckgo.yml
+++ b/serpinfo/duckduckgo.yml
@@ -11,6 +11,8 @@ pages:
       - https://safe.duckduckgo.com/?*
       - https://start.duckduckgo.com/
       - https://start.duckduckgo.com/?*
+      - https://noai.duckduckgo.com/
+      - https://noai.duckduckgo.com/?*
     delay: true
     commonProps:
       $site: duckduckgo


### PR DESCRIPTION
Small change to add the https://noai.duckduckgo.com/ subdomain. I think this is all that's required to fix uBlacklist for that URL...?