### PR TITLE
Specify the button's parent element in Ecosia images

### DIFF
--- a/serpinfo/ecosia.yml
+++ b/serpinfo/ecosia.yml
@@ -25,6 +25,7 @@ pages:
         url: a.image-result__details-link
         props:
           title: h2
+        button: [inset, { top: 0, right: 0 }, ".image-result__link-wrapper"]
         preserveSpace: true
     commonProps:
       $site: ecosia


### PR DESCRIPTION
Because adding the button to the root element broke the image preview (more details in https://github.com/iorate/ublacklist/issues/635)

I see there is a "lastModified" property but it never got updated in this file or any of the others despite them getting modified, is that not needed here?